### PR TITLE
fix: refactor import statement for MutableSequence to use collections.abc

### DIFF
--- a/pydlm_lite/modeler/dynamic.py
+++ b/pydlm_lite/modeler/dynamic.py
@@ -15,7 +15,7 @@ The name dynamic means that the features are changing over time.
 
 """
 import numpy as np
-from collections import MutableSequence
+from collections.abc import MutableSequence
 from copy import deepcopy
 
 import pydlm_lite.base.tools as tl


### PR DESCRIPTION
This pull request updates the import statement for `MutableSequence` in the `pydlm_lite/modeler/dynamic.py` file to ensure compatibility with modern Python versions.

Dependency update:

* Changed the import of `MutableSequence` from `collections` to `collections.abc` to comply with Python 3.3+ standards and avoid deprecation warnings.